### PR TITLE
this would probably only happen if the ContainerConfix accidentally h…

### DIFF
--- a/Util-JsonApiSerializer/Serialization/UrlHelper.cs
+++ b/Util-JsonApiSerializer/Serialization/UrlHelper.cs
@@ -27,7 +27,7 @@ namespace UtilJsonApiSerializer.Serialization
         {
             get
             {
-                if (routePrefix != string.Empty)
+                if (!string.IsNullOrEmpty(routePrefix))
                 {
                     root = routePrefix;
                 }


### PR DESCRIPTION
…ad the route prefix line kept in a msvc, but there's no reason not to check for this
