### PR TITLE
FC-29372 For .netcore replace constructor

### DIFF
--- a/NJsonApi.Common.Test/NJsonApi.Common.Test.csproj
+++ b/NJsonApi.Common.Test/NJsonApi.Common.Test.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
   <PropertyGroup>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NJsonApi.Common.Test</RootNamespace>
     <AssemblyName>NJsonApi.Common.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/NJsonApi.Common.Test/packages.config
+++ b/NJsonApi.Common.Test/packages.config
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="5.10.3" targetFramework="net45" />
+  <package id="FluentAssertions" version="5.10.3" targetFramework="net45" requireReinstallation="true" />
   <package id="Moq" version="4.15.2" targetFramework="net45" />
   <package id="NUnit" version="3.12.0" targetFramework="net45" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net45" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net45" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net45" requireReinstallation="true" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net45" requireReinstallation="true" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" requireReinstallation="true" />
 </packages>

--- a/NJsonApi.Test/NJsonApi.Test.csproj
+++ b/NJsonApi.Test/NJsonApi.Test.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\NUnit.3.12.0\build\NUnit.props" Condition="Exists('..\packages\NUnit.3.12.0\build\NUnit.props')" />
   <PropertyGroup>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NJsonApi.Test</RootNamespace>
     <AssemblyName>NJsonApi.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/NJsonApi.Test/app.config
+++ b/NJsonApi.Test/app.config
@@ -8,4 +8,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/NJsonApi.Test/packages.config
+++ b/NJsonApi.Test/packages.config
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.4.0" targetFramework="net45" />
   <package id="FakeItEasy" version="6.2.1" targetFramework="net45" />
-  <package id="FluentAssertions" version="5.10.3" targetFramework="net45" />
+  <package id="FluentAssertions" version="5.10.3" targetFramework="net45" requireReinstallation="true" />
   <package id="Moq" version="4.15.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="11.0.2" targetFramework="net45" />
   <package id="NUnit" version="3.12.0" targetFramework="net45" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net45" />
-  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net45" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net45" requireReinstallation="true" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net45" requireReinstallation="true" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net45" requireReinstallation="true" />
 </packages>

--- a/Util-JsonApiSerializer.Common/Util-JsonApiSerializer.Common.csproj
+++ b/Util-JsonApiSerializer.Common/Util-JsonApiSerializer.Common.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UtilJsonApiSerializer.Common</RootNamespace>
     <AssemblyName>UtilJsonApiSerializer.Common</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <TargetFrameworkProfile />

--- a/Util-JsonApiSerializer.NetCore/IJsonApiSerializerSettings.cs
+++ b/Util-JsonApiSerializer.NetCore/IJsonApiSerializerSettings.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Util_JsonApiSerializer.NetCore
+{
+    public interface IJsonApiSerializerSettings
+    {
+        public string RoutePrefix { get; set; }
+    }
+}

--- a/Util-JsonApiSerializer.NetCore/JsonApiSerializer.cs
+++ b/Util-JsonApiSerializer.NetCore/JsonApiSerializer.cs
@@ -26,6 +26,16 @@ namespace UtilJsonApiSerializer
             _accessor = accessor;
         }
 
+        public JsonApiSerializer(IHttpContextAccessor accessor, string routePrefix)
+        {
+            SerializerConfiguration = new ConfigurationBuilder();
+            _routePrefix = string.IsNullOrEmpty(routePrefix) ? "" : routePrefix;
+            _accessor = accessor;
+        }
+
+
+
+
         public object SerializeObject(ConfigurationBuilder serializerConfig, object obj)
         {
             var config = serializerConfig.Build();

--- a/Util-JsonApiSerializer.NetCore/JsonApiSerializer.cs
+++ b/Util-JsonApiSerializer.NetCore/JsonApiSerializer.cs
@@ -1,0 +1,64 @@
+
+    using Microsoft.AspNetCore.Http;
+
+using System.Collections.Generic;
+using Util_JsonApiSerializer.NetCore;
+using UtilJsonApiSerializer.Serialization;
+using UtilJsonApiSerializer.Serialization.Documents;
+namespace UtilJsonApiSerializer
+{
+    public class JsonApiSerializer : IJsonApiSerializer
+    {
+        private readonly string _routePrefix;
+
+        public ConfigurationBuilder SerializerConfiguration { get; set; }
+// In Net Core we do not have access to the Http Context directly, so we need to inject it via httpContextAccessor
+
+        private IHttpContextAccessor _accessor;
+        private IJsonApiSerializerSettings _settings;
+        public JsonApiSerializer(
+            IHttpContextAccessor accessor, 
+            IJsonApiSerializerSettings settings
+            )
+        {
+            SerializerConfiguration = new ConfigurationBuilder();
+            _routePrefix = settings == null ? "" : settings.RoutePrefix;
+            _accessor = accessor;
+        }
+
+        public object SerializeObject(ConfigurationBuilder serializerConfig, object obj)
+        {
+            var config = serializerConfig.Build();
+            RunPreSerializationPipelineModules(config, obj);
+
+            var sut = new JsonApiTransformer() { TransformationHelper = new TransformationHelper(_accessor) };
+
+            CompoundDocument result = sut.Transform(obj, new Context() { Configuration = config, RoutePrefix = _routePrefix });
+
+            return result;
+        }
+
+        private void RunPreSerializationPipelineModules(Configuration config, object objectData)
+        {
+            var objectType = TransformationHelper.GetObjectType(objectData);
+            var preSerializerPipelineModule = config.GetPreSerializerPipelineModule(objectType);
+            if (preSerializerPipelineModule != null)
+            {
+                if (objectData is IEnumerable<object> enumerableData)
+                {
+                    foreach (var item in enumerableData)
+                    {
+                        preSerializerPipelineModule.Run(item);
+                    }
+                }
+                else
+                {
+                    preSerializerPipelineModule.Run(objectData);
+                }
+                
+            }
+        }
+
+
+    }
+}

--- a/Util-JsonApiSerializer.NetCore/JsonApiSerializerSettings.cs
+++ b/Util-JsonApiSerializer.NetCore/JsonApiSerializerSettings.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Util_JsonApiSerializer.NetCore
+{
+    public class JsonApiSerializerSettings : IJsonApiSerializerSettings
+    {
+        public string RoutePrefix { get; set; } = "api";
+    }
+}

--- a/Util-JsonApiSerializer.NetCore/Util-JsonApiSerializer.NetCore.csproj
+++ b/Util-JsonApiSerializer.NetCore/Util-JsonApiSerializer.NetCore.csproj
@@ -42,7 +42,6 @@
     <Compile Include="..\Util-JsonApiSerializer\IResourceConfigurationBuilder.cs" Link="IResourceConfigurationBuilder.cs" />
     <Compile Include="..\Util-JsonApiSerializer\IResourceMapping.cs" Link="IResourceMapping.cs" />
     <Compile Include="..\Util-JsonApiSerializer\ISerializerPipelineModule.cs" Link="ISerializerPipelineModule.cs" />
-    <Compile Include="..\Util-JsonApiSerializer\JsonApiSerializer.cs" Link="JsonApiSerializer.cs" />
     <Compile Include="..\Util-JsonApiSerializer\LinkMapping.cs" Link="LinkMapping.cs" />
     <Compile Include="..\Util-JsonApiSerializer\ResourceConfigurationBuilder.cs" Link="ResourceConfigurationBuilder.cs" />
     <Compile Include="..\Util-JsonApiSerializer\ResourceMapping.cs" Link="ResourceMapping.cs" />

--- a/Util-JsonApiSerializer/Util-JsonApiSerializer.csproj
+++ b/Util-JsonApiSerializer/Util-JsonApiSerializer.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>UtilJsonApiSerializer</RootNamespace>
     <AssemblyName>UtilJsonApiSerializer</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <TargetFrameworkProfile />

--- a/Util-JsonApiSerializer/app.config
+++ b/Util-JsonApiSerializer/app.config
@@ -8,4 +8,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>


### PR DESCRIPTION
Replace the route prefix string in the constructor to use an settings interface. That way .netcore can use dependency injection.

Also use .net 4.8 framework requirement in VS
