### PR TITLE
Updated sonar scanner cli Image

### DIFF
--- a/ci/codefresh-build.yml
+++ b/ci/codefresh-build.yml
@@ -58,7 +58,7 @@ steps:
     when: {steps: [{name: BuildingDockerImage, on: [success]}]}
     title: Running Sonar Analysis
     stage: Scan
-    image: sonarsource/sonar-scanner-cli:4.6
+    image: sonarsource/sonar-scanner-cli:${{SONAR_SCANNER_CLI_IMAGE_TAG}}
     commands:
         - "sonar-scanner -Dsonar.host.url=${SONAR_URL} -Dsonar.login=${SONAR_TOKEN} -Dsonar.projectKey=cf_${{CF_REPO_NAME}} -Dsonar.projectName=cf_${{CF_REPO_NAME}} -Dsonar.sources=./ -Dsonar.projectBaseDir=/codefresh/volume/${{CF_REPO_NAME}}/ -Dsonar.projectVersion=${TAG} -Dsonar.branch.name=${{CF_BRANCH}}"
  


### PR DESCRIPTION
we have updated sonar scanner cli version to 5.0.1, to run the scanning with sonar qube sever 2025 version. variable added in codefresh sonarconfig with ${{SONAR_SCANNER_CLI_IMAGE_TAG}}.

**Story/Card:**

[STORYNUM](http://url)

**What does this PR do?**

**Where should reviewer start?**

**Image showing how you feel about this PR [click here for giphy]:(http://giphy.com)**

